### PR TITLE
Changes play-services-gcm version from 8.1.0 to +

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -54,7 +54,7 @@
       <source-file src="src/android/IntercomBridge.java" target-dir="src/io/intercom/android/sdk" />
       <source-file src="src/android/IntercomGCMManager.java" target-dir="src/io/intercom/android/sdk" />
       <framework src="src/android/intercom.gradle" custom="true" type="gradleReference" />
-      <framework src="com.google.android.gms:play-services-gcm:8.1.0" /> 
+      <framework src="com.google.android.gms:play-services-gcm:+" /> 
 
       <config-file target="config.xml" parent="*/">
         <feature name="Intercom">

--- a/plugin.xml
+++ b/plugin.xml
@@ -54,7 +54,7 @@
       <source-file src="src/android/IntercomBridge.java" target-dir="src/io/intercom/android/sdk" />
       <source-file src="src/android/IntercomGCMManager.java" target-dir="src/io/intercom/android/sdk" />
       <framework src="src/android/intercom.gradle" custom="true" type="gradleReference" />
-      <framework src="com.google.android.gms:play-services-gcm:+" /> 
+      <framework src="com.google.android.gms:play-services-gcm:8.+" /> 
 
       <config-file target="config.xml" parent="*/">
         <feature name="Intercom">


### PR DESCRIPTION
With other plugins including `om.google.android.gms:play-services-[libname]:+`, the build would fail with the error reported in https://github.com/intercom/intercom-cordova/issues/31.

I'm not sure why this happens, but I suspect that mixed library versions is a no-go.