### PR TITLE
deviceready not firing on android

### DIFF
--- a/src/android/IntercomBridge.java
+++ b/src/android/IntercomBridge.java
@@ -42,11 +42,7 @@ public class IntercomBridge extends CordovaPlugin {
             cordova.getActivity().getIntent().setData(null);
         }
     }
-
-    @Override public void onNewIntent(Intent intent) {
-        cordova.getActivity().setIntent(intent);
-    }
-
+    
     private void setUpIntercom() {
         cordova.getActivity().runOnUiThread(new Runnable() {
             @Override public void run() {


### PR DESCRIPTION
I've come across a weird issue where 'deviceready' wasn't firing on android due to this plugin.

I narrowed it down to the presence of the `onNewIntent` function - removing it fixed my problem. I know almost nothing about android cordova plugins, so not sure whether this is a crucial bit of code or not, but everything seems to work OK without it.

I'm not sure if there's anything specific in my setup that is triggering this. I am using:

* Crosswalk
* Universal links plugin
* Android 5.0.2
