### PR TITLE
Add Photos framework, required by bundled Intercom framework.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,7 @@
 
       <framework src="Foundation.framework" />
       <framework src="UIKit.framework" />
+      <framework src="Photos.framework" />
       <framework src="Accelerate.framework" />
       <framework src="Security.framework" />
       <framework src="SystemConfiguration.framework" />


### PR DESCRIPTION
This fixes a compile issue in the latest version of the plugin, where the Intercom dependency Photos.framework is not added to build.