### PR TITLE
Add missing permissions for push notifications.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -63,6 +63,11 @@
           <param name="onload" value="true" />
         </feature>
       </config-file>
+      <config-file target="AndroidManifest.xml" parent="/manifest">
+        <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE"/>
+        <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE"/>
+        <permission android:name="${applicationId}.permission.C2D_MESSAGE" android:protectionLevel="signature"/>
+      </config-file>
     </platform>
 
 </plugin>


### PR DESCRIPTION
We are using v1.1.7. Android notifications were not working until we added the C2D permissions.