### PR TITLE
Adding a 'setup' method so the api keys can be set via javascript bridge

### DIFF
--- a/src/android/IntercomBridge.java
+++ b/src/android/IntercomBridge.java
@@ -48,8 +48,9 @@ public class IntercomBridge extends CordovaPlugin {
             @Override public void run() {
                 //We also initialize intercom here just in case it has died. If Intercom is already set up, this won't do anything.
                 setUpIntercom();
-
-                Intercom.client().handlePushMessage();
+                if (Injector.get() != null && Injector.get().getApi() != null) {
+                    Intercom.client().handlePushMessage();
+                }
             }
         });
     }
@@ -81,13 +82,38 @@ public class IntercomBridge extends CordovaPlugin {
             String apiKey = IntercomBridge.this.preferences.getString("intercom-android-api-key", bundle.getString("intercom_api_key"));
             String appId = IntercomBridge.this.preferences.getString("intercom-app-id", bundle.getString("intercom_app_id"));
 
-            Intercom.initialize(IntercomBridge.this.cordova.getActivity().getApplication(), apiKey, appId);
+            if (apiKey != null) {
+                Intercom.initialize(IntercomBridge.this.cordova.getActivity().getApplication(), apiKey, appId);
+            }
         } catch (Exception e) {
             System.err.println("[Intercom-Cordova] ERROR: Something went wrong when initializing Intercom. Have you set your APP_ID and ANDROID_API_KEY?");
         }
     }
 
     private enum Action {
+        setup {
+            @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
+                Context context = cordova.getActivity().getApplicationContext();
+
+                JSONObject options = args.optJSONObject(0);
+                String appId = options.optString("intercom-app-id");
+                String apiKey = options.optString("intercom-android-api-key");
+                String senderId = options.optString("intercom-android-sender-id");
+
+                switch (IntercomPushManager.getInstalledModuleType()) {
+                    case GCM: {
+                        if (senderId != null) {
+                            IntercomPushManager.cacheSenderId(context, senderId);
+                        }
+                        break;
+                    }
+                }
+
+                Intercom.initialize(cordova.getActivity().getApplication(), apiKey, appId);
+
+                callbackContext.success();
+            }
+        },
         registerIdentifiedUser {
             @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
                 JSONObject options = args.optJSONObject(0);

--- a/src/ios/IntercomBridge.h
+++ b/src/ios/IntercomBridge.h
@@ -4,6 +4,8 @@
 
 @interface IntercomBridge : CDVPlugin
 
+- (void)setup:(CDVInvokedUrlCommand*)command;
+
 - (void)registerIdentifiedUser:(CDVInvokedUrlCommand*)command;
 - (void)registerUnidentifiedUser:(CDVInvokedUrlCommand*)command;
 - (void)reset:(CDVInvokedUrlCommand*)command;

--- a/src/ios/IntercomBridge.m
+++ b/src/ios/IntercomBridge.m
@@ -18,7 +18,18 @@
     NSString* apiKey = self.commandDelegate.settings[@"intercom-ios-api-key"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IntercomApiKey"];
     NSString* appId = self.commandDelegate.settings[@"intercom-app-id"] ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"IntercomAppId"];
 
+    if (appId != nil) {
+        [Intercom setApiKey:apiKey forAppId:appId];
+    }
+}
+
+- (void)setup:(CDVInvokedUrlCommand*)command {
+    NSDictionary* options = command.arguments[0];
+    NSString* appId  = options[@"intercom-app-id"];
+    NSString* apiKey = options[@"intercom-ios-api-key"];
+
     [Intercom setApiKey:apiKey forAppId:appId];
+    [self sendSuccess:command];
 }
 
 - (void)registerIdentifiedUser:(CDVInvokedUrlCommand*)command {

--- a/www/intercom.js
+++ b/www/intercom.js
@@ -1,4 +1,8 @@
 var intercom = {
+    setup: function(options, success, error) {
+        cordova.exec(success, error, 'Intercom', 'setup', [options]);
+    },
+
     registerIdentifiedUser: function(options, success, error) {
         cordova.exec(success, error, 'Intercom', 'registerIdentifiedUser', [options]);
     },


### PR DESCRIPTION
I've added a `setup` method that can be called, so the API keys, etc, can be configured via Javascript.

This is a lot better than configuring it via the `Config.xml` file.   The problem with the config.xml, is that it doesn't support multiple Intercom regions.


In Intercom, we have enabled the "test" region for our account, and as such we need our mobile app to support it.

So this PR lets us do that, as we can now use Gulp and other build tools to set the API keys via Javascript configuration files.

It still allows the plugin to work with the Config.xml method too.


Hope you will accept this PR!