### PR TITLE
Add NSPhotoLibraryUsageDescription to info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,10 @@
         </feature>
       </config-file>
 
+      <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+        <string>Attach images to your messages.</string>
+      </config-file>
+
       <header-file src="src/ios/Intercom.framework/Versions/A/Headers/Intercom.h" />
       <source-file src="src/ios/Intercom.framework/Versions/A/Intercom" framework="true" />
       <resource-file src="src/ios/Intercom.framework/Versions/A/Resources/Intercom.bundle" />


### PR DESCRIPTION
Hey guys. We have noticed that the app is missing the `NSPhotoLibraryUsageDescription` for itunes submission. This is needed in order to work with iOS 10. It would be great to add it here, as the package requires PhotoLibraryUsage to attach images to the messages.