### PR TITLE
Build Example app on Travis CI/CircleCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: objective-c
+
+node_js:
+  - 5.10
+
+sudo: false
+
+install:
+  - npm install -g cordova
+
+before_script:
+  - cd Example
+  - cordova platform add ios
+  - cordova plugin add ..
+
+script:
+  - cordova build ios

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,13 @@
+general:
+  build_dir: Example
+
+dependencies:
+  override:
+    - npm install -g cordova
+test:
+  pre:
+    - echo y | android update sdk -u --filter "extra-google-m2repository, extra-android-m2repository"
+    - cordova platform add android
+    - cordova plugin add ..
+  override:
+    - cordova build android


### PR DESCRIPTION
This adds the necessary configuration to build the Example app on CircleCI (Android) and TravisCI (iOS).