### PR TITLE
Add NSPhotoLibraryUsageDescription to Info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -32,6 +32,10 @@
         </feature>
       </config-file>
 
+      <config-file target="*-Info.plist" parent="NSPhotoLibraryUsageDescription">
+        <string>Send photos in your messages to the app.</string>
+      </config-file>
+
       <header-file src="src/ios/Intercom.framework/Versions/A/Headers/Intercom.h" />
       <source-file src="src/ios/Intercom.framework/Versions/A/Intercom" framework="true" />
       <resource-file src="src/ios/Intercom.framework/Versions/A/Resources/Intercom.bundle" />


### PR DESCRIPTION
After reconsidering the best approach, this PR adds `NSPhotoLibraryUsageDescription` as was suggested in #91.