### PR TITLE
Simplified FCM implementation

### DIFF
--- a/src/android/intercom.gradle
+++ b/src/android/intercom.gradle
@@ -1,7 +1,21 @@
-def pushType = ''
-new XmlSlurper().parse(file('../../config.xml')).preference.each {
-    if (it.@name.text() == 'intercom-android-push-type') {
-        pushType = it.@value.text().toLowerCase()
+buildscript {
+    ext {
+        pushType = ''
+        new XmlSlurper().parse(file('../../config.xml')).preference.each {
+            if (it.@name.text() == 'intercom-android-push-type') {
+                pushType = it.@value.text().toLowerCase()
+            }
+        }
+    }
+    repositories {
+        jcenter()
+        mavenLocal()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:+'
+        if (pushType == 'fcm') {
+            classpath 'com.google.gms:google-services:3.0.0'
+        }
     }
 }
 
@@ -19,5 +33,5 @@ dependencies {
 }
 
 if (pushType == 'fcm') {
-    apply plugin: 'com.google.gms.google-services'
+    apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
 }

--- a/src/android/setupFcm.js
+++ b/src/android/setupFcm.js
@@ -17,27 +17,8 @@ module.exports = function(ctx) {
             console.log("Intercom: If you wish to use FCM push notifications, you'll need to add a google-services.json file with the FCM project_info and place that into your project's root folder");
             deferral.resolve();
         } else {
-            fs.createReadStream(settingsFile).pipe(fs.createWriteStream('platforms/android/google-services.json'));
-
-            var lineReader = readline.createInterface({
-                terminal: false,
-                input : fs.createReadStream('platforms/android/build.gradle')
-            });
-            var classPathCount = 0;
-            lineReader.on("line", function(line) {
-                fs.appendFileSync('./build.gradle.tmp', line.toString() + os.EOL);
-                if (/.*\ dependencies \{.*/.test(line)) {
-                    fs.appendFileSync('./build.gradle.tmp', '\t\tclasspath "com.google.gms:google-services:3.0.0"' + os.EOL);
-                } else if (/.*classpath( |\t)+(\"|')com.google.gms:google-services:.*/.test(line)) {
-                    classPathCount = classPathCount + 1;
-                }
-            }).on("close", function () {
-                if (classPathCount == 0) {
-                    fs.rename('./build.gradle.tmp', 'platforms/android/build.gradle', deferral.resolve);
-                } else {
-                    fs.unlink('./build.gradle.tmp', deferral.resolve)
-                }
-            });
+            var stream = fs.createReadStream(settingsFile).pipe(fs.createWriteStream('platforms/android/google-services.json'));
+            stream.on('finish', deferral.resolve);
         }
     });
     return deferral.promise;


### PR DESCRIPTION
This simplifies our FCM implementation by reducing our reliance on hooks by including the classpath directly from our own gradle file.

Related to https://github.com/intercom/intercom-cordova/issues/148.

The hook is still necessary for copying `google-services.json` into the correct location.