### PR TITLE
Add 'remote-notification' background mode to Info.plist

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -38,6 +38,12 @@
         <string>Send photos in your messages to the app.</string>
       </config-file>
 
+      <config-file target="*-Info.plist" parent="UIBackgroundModes">
+        <array>
+          <string>remote-notification</string>
+        </array>
+      </config-file>
+
       <framework src="Intercom" type="podspec" spec="~> 3.1.0" />
     </platform>
 


### PR DESCRIPTION
On iOS 10, push notification token generating can fail if `remote-notification` is not present in `Info.plist`.