### PR TITLE
Release 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Intercom for Cordova/PhoneGap
 
-## 3.1.0 (2016-03-10)
+## 3.1.1 (2017-03-16)
+
+* Removed reliance on hooks for Android FCM support. Gradle is now used for the whole process.
+* Improved iOS interoperability with `phonegap-plugin-push` (Fixes [#154](https://github.com/intercom/intercom-cordova/issues/154)).
+* Automatically add `remote-notification` background mode to the app's `Info.plist` on iOS.
+* Updated minimum Intercom for iOS version to [3.1.2](https://github.com/intercom/intercom-ios/releases/tag/3.1.2).
+
+## 3.1.0 (2017-03-10)
 
 * Updated Intercom for Android to [3.1.x](https://github.com/intercom/intercom-android/releases/).
 * FCM push notifications for Android are now supported. This can be configured by specifying `intercom-android-push-type` in your `config.xml`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~3.1.0" />
+<plugin name="cordova-plugin-intercom" version="~3.1.1" />
 ```
 ### Ionic
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="3.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="3.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>

--- a/src/android/IntercomBridge.java
+++ b/src/android/IntercomBridge.java
@@ -66,7 +66,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = IntercomBridge.this.cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "3.1.0");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "3.1.1");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case GCM: {

--- a/src/ios/IntercomBridge.m
+++ b/src/ios/IntercomBridge.m
@@ -9,7 +9,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"3.1.0"];
+    [Intercom setCordovaVersion:@"3.1.1"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
* Removed reliance on hooks for Android FCM support. Gradle is now used for the whole process.
* Improved iOS interoperability with `phonegap-plugin-push` (Fixes [#154](https://github.com/intercom/intercom-cordova/issues/154)).
* Automatically add `remote-notification` background mode to the app's `Info.plist` on iOS.
* Updated minimum Intercom for iOS version to [3.1.2](https://github.com/intercom/intercom-ios/releases/tag/3.1.2).