### PR TITLE
Enable compatibility with other Android GCM providers

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -50,6 +50,7 @@
     <platform name="android">
       <source-file src="src/android/IntercomBridge.java" target-dir="src/io/intercom/android/sdk" />
       <source-file src="src/android/CordovaHeaderInterceptor.java" target-dir="src/io/intercom/android/sdk" />
+      <source-file src="src/android/IntercomIntentService.java" target-dir="src/io/intercom/android/sdk" />
 
       <framework src="src/android/intercom.gradle" custom="true" type="gradleReference" />
       <framework src="src/android/build-extras-intercom.gradle" custom="true" type="gradleReference" />
@@ -59,6 +60,16 @@
           <param name="android-package" value="io.intercom.android.sdk.IntercomBridge" />
           <param name="onload" value="true" />
         </feature>
+      </config-file>
+      <config-file target="AndroidManifest.xml" parent="/manifest/application">
+        <service
+            android:name="io.intercom.android.sdk.IntercomIntentService"
+            android:exported="false">
+            <intent-filter
+                android:priority="999">
+                <action android:name="com.google.android.c2dm.intent.RECEIVE"/>
+            </intent-filter>
+        </service>
       </config-file>
     </platform>
 

--- a/src/android/IntercomIntentService.java
+++ b/src/android/IntercomIntentService.java
@@ -1,0 +1,46 @@
+package io.intercom.android.sdk;
+
+import android.app.IntentService;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ResolveInfo;
+
+import java.util.List;
+
+import io.intercom.android.sdk.push.IntercomPushClient;
+
+public class IntercomIntentService extends IntentService {
+    private final IntercomPushClient intercomPushClient = new IntercomPushClient();
+
+    public IntercomIntentService() {
+        super("Intercom Cordova Intent Service");
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        if (intercomPushClient.isIntercomPush(intent.getExtras())) {
+            intercomPushClient.handlePush(getApplication(), intent.getExtras());
+            return;
+        }
+
+        Intent passThroughIntent = new Intent(intent);
+        passThroughIntent.setComponent(null);
+
+        List<ResolveInfo> services = getPackageManager().queryIntentServices(passThroughIntent, 0);
+        for (ResolveInfo info : services) {
+            try {
+                Class serviceClass = Class.forName(info.serviceInfo.name);
+                if (serviceClass == this.getClass()) {
+                    continue;
+                }
+
+                Context applicationContext = getApplicationContext();
+                passThroughIntent.setClass(applicationContext, serviceClass);
+                applicationContext.startService(passThroughIntent);
+                return;
+            } catch (ClassNotFoundException e) {
+                // Class not found. Try the next service
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since we built this plugin, there have been many instances of people experiencing issues with Android push notifications when using other push providers (such as phonegap-plugin-push, OneSignal or UrbanAirship). The cause of this has been that Android will only notify one `GcmListenerService` instance of incoming notifications. Here are some of the issues: https://github.com/intercom/intercom-cordova/issues/165, https://github.com/intercom/intercom-cordova/issues/164, https://github.com/intercom/intercom-cordova/issues/139, https://github.com/intercom/intercom-cordova/issues/19, https://github.com/intercom/intercom-cordova/issues/3 and https://github.com/phonegap/phonegap-plugin-push/issues/1640.

The fix until now has been to fork `phonegap-plugin-push`. This is less than ideal and does not address the issue for other plugins.

These changes introduce `IntercomIntentService` which acts as an entry point for all `com.google.android.c2dm.intent.RECEIVE` intents. If the Intent is an Intercom notification, we handle it. Otherwise it is passed to the next highest priority service.

This change will stop the need to use a forked version of `phonegap-plugin-push` as well as allowing Intercom to work alongside other push plugins.

**Note:** this does not fix the issue for FCM. It may be possible to use a similar solution for that in the future.