### PR TITLE
Add hook to ensure CocoaPods specs repo is up to date when installing the plugin

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -21,6 +21,7 @@
 
 
     <platform name="ios">
+      <hook type="before_plugin_install" src="scripts/prepareCocoaPods.js" />
       <hook type="before_build" src="scripts/checkForUpdate.js" />
 
       <header-file src="src/ios/IntercomBridge.h" />

--- a/scripts/prepareCocoaPods.js
+++ b/scripts/prepareCocoaPods.js
@@ -1,0 +1,12 @@
+module.exports = function(context) {
+  var Q = context.requireCordovaModule('q');
+  var deferral = new Q.defer();
+  var exec = context.requireCordovaModule('child_process').exec;
+  
+  console.log('Updating CocoaPods specs repo');
+  exec('pod repo update master', function(error, stdout, stderr) {
+    deferral.resolve();
+  });
+
+  return deferral.promise;
+}


### PR DESCRIPTION
This is a follow up to https://github.com/intercom/intercom-cordova/pull/168.

While `checkForUpdate.js` ensures that Intercom is always up to date, this new hook makes sure that the local specs repo is fully updated when the plugin is installed. In practice that means that cryptic errors like `Error: pod: Command failed with exit code 1` can be avoided.