### PR TITLE
Release 3.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Intercom for Cordova/PhoneGap
 
+## 3.1.3 (2017-04-05)
+
+* Added hook to ensure the local CocoaPods specs repo is up to date when installing the plugin (see [#170](https://github.com/intercom/intercom-cordova/pull/170)).
+
 ## 3.1.2 (2017-03-31)
 
 * Fixed compatibility with other Android GCM providers (details are outlined in [#166](https://github.com/intercom/intercom-cordova/pull/166)). It is no longer necessary to use a fork of `phonegap-plugin-push`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~3.1.2" />
+<plugin name="cordova-plugin-intercom" version="~3.1.3" />
 ```
 ### Ionic
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="3.1.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="3.1.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>
@@ -47,7 +47,7 @@
         </array>
       </config-file>
 
-      <framework src="Intercom" type="podspec" spec="~> 3.1.2" />
+      <framework src="Intercom" type="podspec" spec="~> 3.1.3" />
     </platform>
 
     <platform name="android">

--- a/src/android/IntercomBridge.java
+++ b/src/android/IntercomBridge.java
@@ -66,7 +66,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = IntercomBridge.this.cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "3.1.2");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "3.1.3");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case GCM: {

--- a/src/ios/IntercomBridge.m
+++ b/src/ios/IntercomBridge.m
@@ -9,7 +9,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"3.1.2"];
+    [Intercom setCordovaVersion:@"3.1.3"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
* Added hook to ensure the local CocoaPods specs repo is up to date when installing the plugin (see [#170](https://github.com/intercom/intercom-cordova/pull/170)).