### PR TITLE
Release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Intercom for Cordova/PhoneGap
 
+## 3.2.0 (2017-04-21)
+
+* Added a new method to the API `intercom.setUserHash(userHash)` to support Identity Verification. This method replaces `intercom.setSecureMode(hmac, data)` which was used for our previous security feature Secure Mode.
+* Updated Intercom for Android to 3.2.x.
+* Updated Intercom for iOS to 3.2.x.
+
 ## 3.1.3 (2017-04-05)
 
 * Added hook to ensure the local CocoaPods specs repo is up to date when installing the plugin (see [#170](https://github.com/intercom/intercom-cordova/pull/170)).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~3.1.3" />
+<plugin name="cordova-plugin-intercom" version="~3.2.0" />
 ```
 ### Ionic
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="3.1.3" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="3.2.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>
@@ -47,7 +47,7 @@
         </array>
       </config-file>
 
-      <framework src="Intercom" type="podspec" spec="~> 3.1.3" />
+      <framework src="Intercom" type="podspec" spec="~> 3.2.0" />
     </platform>
 
     <platform name="android">

--- a/src/android/IntercomBridge.java
+++ b/src/android/IntercomBridge.java
@@ -66,7 +66,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = IntercomBridge.this.cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "3.1.3");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "3.2.0");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case GCM: {
@@ -126,6 +126,13 @@ public class IntercomBridge extends CordovaPlugin {
                 String hmac = args.optString(0);
                 String data = args.optString(1);
                 Intercom.client().setSecureMode(hmac, data);
+                callbackContext.success();
+            }
+        },
+        setUserHash {
+            @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
+                String hmac = args.optString(0);
+                Intercom.client().setUserHash(hmac);
                 callbackContext.success();
             }
         },

--- a/src/android/intercom.gradle
+++ b/src/android/intercom.gradle
@@ -23,12 +23,12 @@ repositories {
     jcenter()
 }
 dependencies {
-    compile 'io.intercom.android:intercom-sdk-base:3.1.+'
+    compile 'io.intercom.android:intercom-sdk-base:3.2.+'
     if (pushType == 'gcm') {
-        compile 'io.intercom.android:intercom-sdk-gcm:3.1.+'
+        compile 'io.intercom.android:intercom-sdk-gcm:3.2.+'
     } else if (pushType == 'fcm') {
         compile 'com.google.firebase:firebase-messaging:10.+'
-        compile 'io.intercom.android:intercom-sdk-fcm:3.1.+'
+        compile 'io.intercom.android:intercom-sdk-fcm:3.2.+'
     }
 }
 

--- a/src/ios/IntercomBridge.m
+++ b/src/ios/IntercomBridge.m
@@ -9,7 +9,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"3.1.3"];
+    [Intercom setCordovaVersion:@"3.2.0"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif
@@ -61,6 +61,13 @@
     NSString *data = command.arguments[1];
 
     [Intercom setHMAC:hmac data:data];
+    [self sendSuccess:command];
+}
+
+- (void)setUserHash:(CDVInvokedUrlCommand*)command {
+    NSString *hmac = command.arguments[0];
+
+    [Intercom setUserHash:hmac];
     [self sendSuccess:command];
 }
 

--- a/www/intercom.js
+++ b/www/intercom.js
@@ -15,6 +15,10 @@ var intercom = {
         cordova.exec(success, error, 'Intercom', 'setSecureMode', [secureHash, secureData]);
     },
 
+    setUserHash: function(secureHash, success, error) {
+        cordova.exec(success, error, 'Intercom', 'setUserHash', [secureHash]);
+    },
+
     updateUser: function(attributes, success, error) {
         cordova.exec(success, error, 'Intercom', 'updateUser', [attributes]);
     },


### PR DESCRIPTION
* Added a new method to the API `intercom.setUserHash(userHash)` to support Identity Verification. This method replaces `intercom.setSecureMode(hmac, data)` which was used for our previous security feature Secure Mode.
* Updated Intercom for Android to 3.2.x.
* Updated Intercom for iOS to 3.2.x.