### PR TITLE
Prevent unsafe versions of the Support Library being used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+Example/node_modules

--- a/circle.yml
+++ b/circle.yml
@@ -11,8 +11,8 @@ dependencies:
   override:
     - npm install -g cordova
     - if [ ! -e $ANDROID_HOME/platforms/android-25 ]; then echo y | android update sdk --no-ui --all --filter android-25; fi
-    - if [ ! -e $ANDROID_HOME/extras/android/m2repository/com/android/support/design/25.0.1 ]; then echo y | android update sdk --no-ui --all --filter extra-android-m2repository; fi
-    - if [ ! -e $ANDROID_HOME/extras/google/m2repository/com/google/firebase/firebase-messaging/9.8.0 ]; then echo y | android update sdk --no-ui --all --filter extra-google-m2repository; fi
+    - if [ ! -e $ANDROID_HOME/extras/android/m2repository/com/android/support/design/25.3.1 ]; then echo y | android update sdk --no-ui --all --filter extra-android-m2repository; fi
+    - if [ ! -e $ANDROID_HOME/extras/google/m2repository/com/google/firebase/firebase-messaging/10.2.1 ]; then echo y | android update sdk --no-ui --all --filter extra-google-m2repository; fi
 
   cache_directories:
     # Android SDK

--- a/src/android/build-extras-intercom.gradle
+++ b/src/android/build-extras-intercom.gradle
@@ -5,3 +5,28 @@
 // @link https://issues.apache.org/jira/browse/CB-10014
 def manifest = new XmlSlurper().parse(file("AndroidManifest.xml"))
 android.defaultConfig.applicationId manifest.@package.text()
+
+// some libraries depend on higher versions of our dependencies than we support
+// we keep track of these dependencies here and override the version to a safe one
+def safeVersions = [
+        "com.android.support:support-v4": "25.+"
+]
+
+def badVersionIndicators = [
+        'alpha',
+        'beta',
+        'preview',
+        ',)'
+]
+
+configurations.all {
+    resolutionStrategy.eachDependency {
+        DependencyResolveDetails details ->
+        def safeVersion = safeVersions[details.requested.group + ":" + details.requested.name]
+        def requestedVersion = details.requested.version
+        if (safeVersion != null && badVersionIndicators.any { requestedVersion.contains(it) }) {
+            println "Intercom: Overriding dependency ${details.requested.group}:${details.requested.name} version ${details.requested.version} --> $safeVersion"
+            details.useVersion safeVersion
+        }
+    }
+}


### PR DESCRIPTION
* Change unsafe versions of the Support Library to a known safe version
* Update CircleCI caching logic
* Exclude the `node_modules` from the Example from Git