### PR TITLE
Ignore test dependencies when checking for incompatibilities

### DIFF
--- a/intercom-plugin/src/android/build-extras-intercom.gradle
+++ b/intercom-plugin/src/android/build-extras-intercom.gradle
@@ -67,9 +67,11 @@ private void logIfIncorrectBuildToolsVersion() {
     }
 }
 
-private static Matcher isCompileConfig(config) {
+private static boolean isCompileConfig(config) {
     // these can be `compile` or `{variant}Compile`
-    config.name =~ /^[a-z][a-zA-Z]*ompile/
+    config.name =~ /^[a-z][a-zA-Z]*ompile/ \
+        && !(config.name =~ /^test.*Compile/) \
+        && !(config.name =~ /^androidTest.*Compile/)
 }
 
 private void logIncompatibleDependencies(config) {


### PR DESCRIPTION
Should address this issue: https://github.com/intercom/intercom-cordova/issues/219