### PR TITLE
Only check the `compile` configuration for dependencies

### DIFF
--- a/intercom-plugin/src/android/build-extras-intercom.gradle
+++ b/intercom-plugin/src/android/build-extras-intercom.gradle
@@ -36,7 +36,7 @@ afterEvaluate {
     logIfIncorrectCompileSdkVersion()
     logIfIncorrectBuildToolsVersion()
     configurations
-            .findAll { isCompileConfig(it) }
+            .findAll { it.name == "compile" }
             .each { logIncompatibleDependencies(it) }
 }
 
@@ -65,13 +65,6 @@ private void logIfIncorrectBuildToolsVersion() {
                 "You need to use a cdvBuildToolsVersion of at least 26.0.0.\n" +
                 "See here for more: ${guideUrl()}\n")
     }
-}
-
-private static boolean isCompileConfig(config) {
-    // these can be `compile` or `{variant}Compile`
-    config.name =~ /^[a-z][a-zA-Z]*ompile/ \
-        && !(config.name =~ /^test.*Compile/) \
-        && !(config.name =~ /^androidTest.*Compile/)
 }
 
 private void logIncompatibleDependencies(config) {


### PR DESCRIPTION
There's a very slim chance that any Support Library dependencies will be declared outside of this config, and it appears to be the only one we can safely check: https://github.com/intercom/intercom-cordova/issues/219#issuecomment-344614403