### PR TITLE
Update to Cordova Android 7.0.0

### DIFF
--- a/Example/README.md
+++ b/Example/README.md
@@ -20,15 +20,9 @@ Before you run your app, you'll need to add your Intercom **AppID** and **API Ke
 <preference name="intercom-android-api-key" value="YOUR_ANDROID_API_KEY"/>
 ```
 
-If you want to enable Android FCM push notifications copy your `google-services.json` file into the `Example/` folder add this line to `config.xml`:
+If you want to enable Android FCM/GCM push notifications copy your `google-services.json` file into the `Example/` folder add this line to `config.xml`:
 ```xml
 <preference name="intercom-android-push-type" value="FCM"/>
-```
-
-If you want to enable Android GCM push notifications add these lines to `config.xml`, with your own sender_id:
-```xml
-<preference name="intercom-android-sender-id" value="YOUR_ANDROID_SENDER_ID"/>
-<preference name="intercom-android-push-type" value="GCM"/>
 ```
 
 ## Running the app

--- a/Example/config.xml
+++ b/Example/config.xml
@@ -8,7 +8,6 @@
         Brian Boyle
     </author>
     <content src="index.html" />
-    <plugin name="cordova-plugin-whitelist" version="1.0.0" />
     <access origin="*" />
     <allow-intent href="http://*/*" />
     <allow-intent href="https://*/*" />
@@ -18,7 +17,7 @@
     <allow-intent href="geo:*" />
     <platform name="android">
         <allow-intent href="market:*" />
-        <preference name="android-minSdkVersion" value="15" />
+        <preference name="android-minSdkVersion" value="19" />
         <icon density="hdpi" src="www/img/android/hdpi.png" />
         <icon density="mdpi" src="www/img/android/mdpi.png" />
         <icon density="xhdpi" src="www/img/android/xhdpi.png" />
@@ -53,20 +52,16 @@
         <splash height="2208" src="www/img/launch/Default-736@2x.png" width="1242" />
         <splash height="1242" src="www/img/launch/iPad_landscape_large.png" width="2208" />
     </platform>
+    <preference name="intercom-app-id" value="YOUR_APP_ID" />
+    <preference name="intercom-ios-api-key" value="YOU_IOS_API_KEY" />
+    <preference name="intercom-android-api-key" value="YOUR_ANDROID_API_KEY" />
 
-    <preference name="intercom-app-id" value="YOUR_APP_ID"/>
-    <preference name="intercom-ios-api-key" value="YOU_IOS_API_KEY"/>
-    <preference name="intercom-android-api-key" value="YOUR_ANDROID_API_KEY"/>
-    
-<!--     
+<!--
     Include this line if you wish to use FCM for Android push notifications
-    <preference name="intercom-android-push-type" value="FCM"/>
- -->
-<!--     
-    Include these lines with your GCM sender id if you wish to use GCM for Android push notifications
-    <preference name="intercom-android-sender-id" value="YOUR_ANDROID_SENDER_ID"/>
-    <preference name="intercom-android-push-type" value="GCM"/>
+    <preference name="intercom-android-push-type" value="FCM" />
  -->
 
-    <engine name="ios" spec="~4.5.2" />
+    <plugin name="cordova-plugin-whitelist" spec="1.0.0" />
+    <engine name="android" spec="^7.0.0" />
+    <engine name="ios" spec="^4.5.4" />
 </widget>

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -1,0 +1,535 @@
+{
+  "name": "io.intercom.cordova.sample.gcm",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "cordova-android": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-7.0.0.tgz",
+      "integrity": "sha1-yVvt/PvDhjsYDE0p7/7E95Nh0Z0=",
+      "requires": {
+        "android-versions": "1.2.1",
+        "cordova-common": "2.2.0",
+        "elementtree": "0.1.6",
+        "nopt": "3.0.6",
+        "properties-parser": "0.2.3",
+        "q": "1.5.1",
+        "shelljs": "0.5.3"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "android-versions": {
+          "version": "1.2.1",
+          "bundled": true
+        },
+        "ansi": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "big-integer": {
+          "version": "1.6.26",
+          "bundled": true
+        },
+        "bplist-parser": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "big-integer": "1.6.26"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cordova-common": {
+          "version": "2.2.0",
+          "bundled": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "bplist-parser": "0.1.1",
+            "cordova-registry-mapper": "1.1.15",
+            "elementtree": "0.1.6",
+            "glob": "5.0.15",
+            "minimatch": "3.0.4",
+            "osenv": "0.1.4",
+            "plist": "1.2.0",
+            "q": "1.5.1",
+            "semver": "5.4.1",
+            "shelljs": "0.5.3",
+            "underscore": "1.8.3",
+            "unorm": "1.4.1"
+          }
+        },
+        "cordova-registry-mapper": {
+          "version": "1.1.15",
+          "bundled": true
+        },
+        "elementtree": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "sax": "0.3.5"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "bundled": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "plist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "0.0.8",
+            "util-deprecate": "1.0.2",
+            "xmlbuilder": "4.0.0",
+            "xmldom": "0.1.27"
+          }
+        },
+        "properties-parser": {
+          "version": "0.2.3",
+          "bundled": true
+        },
+        "q": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "0.3.5",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "bundled": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xmlbuilder": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "3.10.1"
+          }
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "bundled": true
+        }
+      }
+    },
+    "cordova-ios": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/cordova-ios/-/cordova-ios-4.5.4.tgz",
+      "integrity": "sha1-yAZIBYlyloVw3BXalzFP+S0H3+c=",
+      "requires": {
+        "cordova-common": "2.1.0",
+        "ios-sim": "6.1.2",
+        "nopt": "3.0.6",
+        "plist": "1.2.0",
+        "q": "1.5.1",
+        "shelljs": "0.5.3",
+        "xcode": "0.9.3",
+        "xml-escape": "1.1.0"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.1",
+          "bundled": true
+        },
+        "ansi": {
+          "version": "0.3.1",
+          "bundled": true
+        },
+        "balanced-match": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "base64-js": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "big-integer": {
+          "version": "1.6.25",
+          "bundled": true
+        },
+        "bplist-creator": {
+          "version": "0.0.7",
+          "bundled": true,
+          "requires": {
+            "stream-buffers": "2.2.0"
+          }
+        },
+        "bplist-parser": {
+          "version": "0.1.1",
+          "bundled": true,
+          "requires": {
+            "big-integer": "1.6.25"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.8",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "1.0.0",
+            "concat-map": "0.0.1"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "cordova-common": {
+          "version": "2.1.0",
+          "bundled": true,
+          "requires": {
+            "ansi": "0.3.1",
+            "bplist-parser": "0.1.1",
+            "cordova-registry-mapper": "1.1.15",
+            "elementtree": "0.1.6",
+            "glob": "5.0.15",
+            "minimatch": "3.0.4",
+            "osenv": "0.1.4",
+            "plist": "1.2.0",
+            "q": "1.5.1",
+            "semver": "5.4.1",
+            "shelljs": "0.5.3",
+            "underscore": "1.8.3",
+            "unorm": "1.4.1"
+          }
+        },
+        "cordova-registry-mapper": {
+          "version": "1.1.15",
+          "bundled": true
+        },
+        "elementtree": {
+          "version": "0.1.6",
+          "bundled": true,
+          "requires": {
+            "sax": "0.3.5"
+          }
+        },
+        "glob": {
+          "version": "5.0.15",
+          "bundled": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ios-sim": {
+          "version": "6.1.2",
+          "bundled": true,
+          "requires": {
+            "bplist-parser": "0.0.6",
+            "nopt": "1.0.9",
+            "plist": "1.2.0",
+            "simctl": "1.1.1"
+          },
+          "dependencies": {
+            "bplist-parser": {
+              "version": "0.0.6",
+              "bundled": true
+            },
+            "nopt": {
+              "version": "1.0.9",
+              "bundled": true,
+              "requires": {
+                "abbrev": "1.1.1"
+              }
+            }
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "bundled": true
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "bundled": true,
+          "requires": {
+            "abbrev": "1.1.1"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "pegjs": {
+          "version": "0.10.0",
+          "bundled": true
+        },
+        "plist": {
+          "version": "1.2.0",
+          "bundled": true,
+          "requires": {
+            "base64-js": "0.0.8",
+            "util-deprecate": "1.0.2",
+            "xmlbuilder": "4.0.0",
+            "xmldom": "0.1.27"
+          }
+        },
+        "q": {
+          "version": "1.5.1",
+          "bundled": true
+        },
+        "sax": {
+          "version": "0.3.5",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "bundled": true
+        },
+        "shelljs": {
+          "version": "0.5.3",
+          "bundled": true
+        },
+        "simctl": {
+          "version": "1.1.1",
+          "bundled": true,
+          "requires": {
+            "shelljs": "0.2.6",
+            "tail": "0.4.0"
+          },
+          "dependencies": {
+            "shelljs": {
+              "version": "0.2.6",
+              "bundled": true
+            }
+          }
+        },
+        "simple-plist": {
+          "version": "0.2.1",
+          "bundled": true,
+          "requires": {
+            "bplist-creator": "0.0.7",
+            "bplist-parser": "0.1.1",
+            "plist": "2.0.1"
+          },
+          "dependencies": {
+            "base64-js": {
+              "version": "1.1.2",
+              "bundled": true
+            },
+            "plist": {
+              "version": "2.0.1",
+              "bundled": true,
+              "requires": {
+                "base64-js": "1.1.2",
+                "xmlbuilder": "8.2.2",
+                "xmldom": "0.1.27"
+              }
+            },
+            "xmlbuilder": {
+              "version": "8.2.2",
+              "bundled": true
+            }
+          }
+        },
+        "stream-buffers": {
+          "version": "2.2.0",
+          "bundled": true
+        },
+        "tail": {
+          "version": "0.4.0",
+          "bundled": true
+        },
+        "underscore": {
+          "version": "1.8.3",
+          "bundled": true
+        },
+        "unorm": {
+          "version": "1.4.1",
+          "bundled": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "xcode": {
+          "version": "0.9.3",
+          "bundled": true,
+          "requires": {
+            "pegjs": "0.10.0",
+            "simple-plist": "0.2.1",
+            "uuid": "3.0.1"
+          }
+        },
+        "xml-escape": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "xmlbuilder": {
+          "version": "4.0.0",
+          "bundled": true,
+          "requires": {
+            "lodash": "3.10.1"
+          }
+        },
+        "xmldom": {
+          "version": "0.1.27",
+          "bundled": true
+        }
+      }
+    },
+    "cordova-plugin-whitelist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.0.0.tgz",
+      "integrity": "sha1-juxM9EXaTUXE+g/cI5SbJNObazE="
+    }
+  }
+}

--- a/Example/package.json
+++ b/Example/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "io.intercom.cordova.sample",
+  "version": "0.0.1",
+  "displayName": "Intercom Cordova",
+  "cordova": {
+    "platforms": [
+      "android",
+      "ios"
+    ],
+    "plugins": {
+      "cordova-plugin-whitelist": {}
+    }
+  },
+  "dependencies": {
+    "cordova-android": "^7.0.0",
+    "cordova-ios": "^4.5.4",
+    "cordova-plugin-whitelist": "1.0.0"
+  }
+}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 This is a plugin that allows your Cordova or PhoneGap app to use [Intercom for iOS](https://github.com/intercom/intercom-ios) and/or [Intercom for Android](https://github.com/intercom/intercom-android).
 
 * Intercom for iOS supports iOS 8, 9, 10  & 11.
-* Intercom for Android supports API 15 and above.
+* Intercom for Android supports API 19 and above.
 
 ## Installation
 

--- a/intercom-plugin/src/android/build-extras-intercom.gradle
+++ b/intercom-plugin/src/android/build-extras-intercom.gradle
@@ -4,7 +4,7 @@ import java.util.regex.Matcher
 // INSTALL_FAILED_CONFLICTING_PROVIDER error when installing the app.
 // 
 // @link https://issues.apache.org/jira/browse/CB-10014
-def manifest = new XmlSlurper().parse(file("AndroidManifest.xml"))
+def manifest = new XmlSlurper().parse(file("src/main/AndroidManifest.xml"))
 android.defaultConfig.applicationId manifest.@package.text()
 
 // some libraries depend on higher versions of our dependencies than we support

--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext {
         pushType = ''
-        new XmlSlurper().parse(file('../../config.xml')).preference.each {
+        new XmlSlurper().parse(file('../app/src/main/res/xml/config.xml')).preference.each {
             if (it.@name.text() == 'intercom-android-push-type') {
                 pushType = it.@value.text().toLowerCase()
             }
@@ -36,7 +36,7 @@ dependencies {
 }
 
 task copyGoogleServices(type: Copy) {
-    from '../../google-services.json'
+    from '../../../google-services.json'
     into '.'
 }
 


### PR DESCRIPTION
This update includes breaking changes dictated by `cordova-android`'s 7.0.0 release as documented here: https://cordova.apache.org/announcements/2017/12/04/cordova-android-7.0.0.html. When released, all Cordova project using the new release of `intercom-cordova` will need to use the `cordova-android` 7.0.0 or greater, which incidentally is bundled with Cordova 8.0.0 by default, though can be specified on older versions (tested on[ Cordova 7.1.0](https://github.com/apache/cordova-cli/releases/tag/7.1.0))

Will resolve many current build and GCM/FCM issues open on this repo. Will validate each issue fix individually upon release.