### PR TITLE
Fix GCM sender ID reading

### DIFF
--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -15,7 +15,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.3.+'
         if (pushType == 'fcm') {
-            classpath 'com.google.gms:google-services:3.1.0'
+            classpath 'com.google.gms:google-services:3.2.0'
         }
     }
 }
@@ -35,12 +35,31 @@ dependencies {
     }
 }
 
+def googleServicesJsonPath = '../../../google-services.json'
+
 task copyGoogleServices(type: Copy) {
-    from '../../../google-services.json'
+    from googleServicesJsonPath
     into '.'
 }
 
-if (pushType == 'fcm') {
+if (pushType == 'gcm') {
+    try {
+        def jsonFile = file(googleServicesJsonPath)
+        def parsedJson = new groovy.json.JsonSlurper().parseText(jsonFile.text)
+        def senderId = parsedJson.project_info.project_number
+
+        android {
+            defaultConfig {
+                resValue "string", "intercom_gcm_sender_id", senderId
+                buildConfigField "String", 'INTERCOM_SENDER_ID', "\"${senderId}\""
+            }
+        }
+    } catch (Exception e) {
+        logger.error("Could not read sender ID from google-services.json, falling back to " +
+                "`intercom-android-sender-id` preference:" + e.getMessage())
+    }
+
+} else if (pushType == 'fcm') {
     tasks.copyGoogleServices.execute()
     apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
 }


### PR DESCRIPTION
When reading the GCM sender ID from `config.xml`, the Android OS XML parser can read it in as a string representation of a float, including scientific notation. This string is unusable as a sender ID.

To fix this, we read the sender ID directly from the `google-services.json` file if it's present. If the sender ID from the preferences is missing, or unusable, we return the ID from the JSON file.

This PR also includes some cleanup of the `IntercomBridge` class.