### PR TITLE
Allow FCM notifications without applying build plugin

### DIFF
--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -62,4 +62,7 @@ if (pushType == 'gcm') {
 } else if (pushType == 'fcm') {
     tasks.copyGoogleServices.execute()
     apply plugin: com.google.gms.googleservices.GoogleServicesPlugin
+} else if (pushType == 'fcm-without-build-plugin') {
+    tasks.copyGoogleServices.execute()
+    logger.info("Not applying GoogleServicesPlugin from Intercom plugin, another plugin should do this")
 }


### PR DESCRIPTION
This will allow apps using FCM Intercom push notifications to build when another Cordova plugin applies the Google Services Gradle plugin.