### PR TITLE
Release version 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Intercom for Cordova/PhoneGap
 
+## 5.1.0 (2018-02-12)
+
+* Created fork of `phonegap-plugin-push` to allow it to work with this plugin: https://github.com/intercom/phonegap-plugin-push
+* Allow FCM notifications without applying build plugin [#253](https://github.com/intercom/intercom-cordova/pull/253)
+* Update recommended build tool & library versions [#252](https://github.com/intercom/intercom-cordova/pull/252)
+* Remove broken support for multiple GCM libraries [#251](https://github.com/intercom/intercom-cordova/pull/251)
+* Fix GCM sender ID reading [#250](https://github.com/intercom/intercom-cordova/pull/250)
+* Change hook for checkForUpdate to be after_prepare [#249](https://github.com/intercom/intercom-cordova/pull/249)
+
 ## 5.0.2 (2018-02-12)
 
 * Fix issue with Intercom pod not being updated / installed when GitHub response was not 200 OK: [#246](https://github.com/intercom/intercom-cordova/pull/246)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~5.0.2" />
+<plugin name="cordova-plugin-intercom" version="~5.1.0" />
 ```
 ### Ionic
 

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="5.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="5.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -59,7 +59,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "5.0.2");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "5.1.0");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case GCM: {

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -9,7 +9,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"5.0.2"];
+    [Intercom setCordovaVersion:@"5.1.0"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
* Created fork of `phonegap-plugin-push` to allow it to work with this plugin: https://github.com/intercom/phonegap-plugin-push
* Allow FCM notifications without applying build plugin [#253](https://github.com/intercom/intercom-cordova/pull/253)
* Update recommended build tool & library versions [#252](https://github.com/intercom/intercom-cordova/pull/252)
* Remove broken support for multiple GCM libraries [#251](https://github.com/intercom/intercom-cordova/pull/251)
* Fix GCM sender ID reading [#250](https://github.com/intercom/intercom-cordova/pull/250)
* Change hook for checkForUpdate to be after_prepare [#249](https://github.com/intercom/intercom-cordova/pull/249)