### PR TITLE
Include FCM libraries when building without build plugin

### DIFF
--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'io.intercom.android:intercom-sdk-base:4.1.+'
     if (pushType == 'gcm') {
         compile 'io.intercom.android:intercom-sdk-gcm:4.1.+'
-    } else if (pushType == 'fcm') {
+    } else if (pushType == 'fcm' || pushType == 'fcm-without-build-plugin') {
         compile 'com.google.firebase:firebase-messaging:11.+'
         compile 'io.intercom.android:intercom-sdk-fcm:4.1.+'
     }


### PR DESCRIPTION
This is needed for FCM notifications to be delivered when the build plugin is not used.