### PR TITLE
Release version 5.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Intercom for Cordova/PhoneGap
 
-## 5.1.0 (2018-02-12)
+## 5.1.1 (2018-02-26)
+
+* Include FCM libraries when building without build plugin [#257](https://github.com/intercom/intercom-cordova/pull/257)
+
+## 5.1.0 (2018-02-26)
 
 * Created fork of `phonegap-plugin-push` to allow it to work with this plugin: https://github.com/intercom/phonegap-plugin-push
 * Allow FCM notifications without applying build plugin [#253](https://github.com/intercom/intercom-cordova/pull/253)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~5.1.0" />
+<plugin name="cordova-plugin-intercom" version="~5.1.1" />
 ```
 ### Ionic
 

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="5.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="5.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -59,7 +59,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "5.1.0");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "5.1.1");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case GCM: {

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -9,7 +9,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"5.1.0"];
+    [Intercom setCordovaVersion:@"5.1.1"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
* Include FCM libraries when building without build plugin [#257](https://github.com/intercom/intercom-cordova/pull/257)