### PR TITLE
Add function to send firebase token to Intercom when intercom-android-push-type is set to FCM-WITHOUT-BUILD-PLUGIN

### DIFF
--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -23,6 +23,7 @@ import io.intercom.android.sdk.api.CordovaHeaderInterceptor;
 import io.intercom.android.sdk.api.UserUpdateRequest;
 import io.intercom.android.sdk.identity.Registration;
 import io.intercom.android.sdk.logger.LumberMill;
+import io.intercom.android.sdk.push.IntercomPushClient;
 public class IntercomBridge extends CordovaPlugin {
 
     private static final String CUSTOM_ATTRIBUTES = "custom_attributes";
@@ -241,6 +242,13 @@ public class IntercomBridge extends CordovaPlugin {
         registerForPush {
             @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
                 //This doesn't need to do anything on Android
+            }
+        },
+        sendPushTokenToIntercom {
+            @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
+                String token = args.optString(0);
+                IntercomPushClient intercomPushClient = new IntercomPushClient();
+                intercomPushClient.sendTokenToIntercom(cordova.getActivity().getApplication(), token);
             }
         },
         unknown {

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -149,6 +149,10 @@
     [self sendSuccess:command];
 }
 
+- (void)sendPushTokenToIntercom:(CDVInvokedUrlCommand*)command {
+  NSLog(@"[Intercom-Cordova] INFO - sendPushTokenToIntercom called");
+}
+
 #pragma mark - User attributes
 
 - (ICMUserAttributes *)userAttributesForDictionary:(NSDictionary *)attributesDict {

--- a/intercom-plugin/www/intercom.js
+++ b/intercom-plugin/www/intercom.js
@@ -72,6 +72,10 @@ var intercom = {
 
     registerForPush: function(success, error) {
         cordova.exec(success, error, 'Intercom', 'registerForPush', []);
+    },
+
+    sendPushTokenToIntercom: function(token, success, error) {
+        cordova.exec(success, error, 'Intercom', 'sendPushTokenToIntercom', [token]);
     }
 }
 


### PR DESCRIPTION
The changes allow to use cordova-plugin-intercom side by side with other plugins which also use GoogleServices. In my case I had an issue when using cordova-plugin-firebase at compile time.
Setting intercom-android-push-type to FCM-WITHOUT-BUILD-PLUGIN in config.xml solved the compile issue but then I was not able to send push notifications via Intercom.
My assumption was that the firebase token maybe wasn't sent to Intercom anymore. Therefore I added another function which allows to send this token manually from my Firebase component.