### PR TITLE
Release 6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Intercom for Cordova/PhoneGap
 
+## 6.1.0 (2018-07-20)
+
+**Enable mobile users to help themselves with the new mobile SDK for iOS and Android 🎉 😃**
+
+The new Intercom mobile SDK brings the Messenger Home to your mobile applications. This means you can add messenger apps that allow your users to self-serve instead of starting a conversation. Users can now quickly access relevant help articles, review pinned content, and view product status in real time – all from the messenger home screen.
+
+![android-release-screens](https://user-images.githubusercontent.com/2615468/42951497-316de29a-8b6e-11e8-8ed8-a0a3a93f6f4f.png)
+
+![ios-release-screens](https://user-images.githubusercontent.com/3185423/42937925-71ab4b5c-8b48-11e8-913b-88d48c9b82f3.png)
+
+**API changes**
+
+* `displayConversationsList` - Use `displayMessenger` instead.
+
+These deprecated methods will still work, but will be removed in a future release. 
+
 ## 6.0.0 (2018-06-12)
 
 The Business Messenger reimagined.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~5.1.1" />
+<plugin name="cordova-plugin-intercom" version="~6.1.0" />
 ```
 ### Ionic
 

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="6.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="6.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>
@@ -47,7 +47,7 @@
         </array>
       </config-file>
 
-      <framework src="Intercom" type="podspec" spec="~> 5.0.0" />
+      <framework src="Intercom" type="podspec" spec="~> 5.1.0" />
     </platform>
 
     <platform name="android">

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -59,7 +59,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "5.1.1");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "6.1.0");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case GCM: {
@@ -185,7 +185,8 @@ public class IntercomBridge extends CordovaPlugin {
         },
         displayConversationsList {
             @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
-                Intercom.client().displayConversationsList();
+                LumberMill.getLogger().w("displayConversationsList is deprecated. Please use displayMessenger instead.");
+                Intercom.client().displayMessenger();
                 callbackContext.success();
             }
         },

--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -26,12 +26,12 @@ repositories {
 }
 
 dependencies {
-    compile 'io.intercom.android:intercom-sdk-base:5.0.+'
+    compile 'io.intercom.android:intercom-sdk-base:5.1.+'
     if (pushType == 'gcm') {
-        compile 'io.intercom.android:intercom-sdk-gcm:5.0.+'
+        compile 'io.intercom.android:intercom-sdk-gcm:5.1.+'
     } else if (pushType == 'fcm' || pushType == 'fcm-without-build-plugin') {
         compile 'com.google.firebase:firebase-messaging:11.+'
-        compile 'io.intercom.android:intercom-sdk-fcm:5.0.+'
+        compile 'io.intercom.android:intercom-sdk-fcm:5.1.+'
     }
 }
 

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -9,7 +9,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"5.1.1"];
+    [Intercom setCordovaVersion:@"6.1.0"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif
@@ -93,18 +93,19 @@
 }
 
 - (void)displayMessageComposer:(CDVInvokedUrlCommand*)command {
-    [Intercom presentMessageComposer];
+    [Intercom presentMessageComposer:nil];
     [self sendSuccess:command];
 }
 
 - (void)displayMessageComposerWithInitialMessage:(CDVInvokedUrlCommand*)command {
     NSString *initialMessage = command.arguments[0];
-    [Intercom presentMessageComposerWithInitialMessage:initialMessage];
+    [Intercom presentMessageComposer:initialMessage];
     [self sendSuccess:command];
 }
 
 - (void)displayConversationsList:(CDVInvokedUrlCommand*)command {
-    [Intercom presentConversationList];
+    NSLog(@"[Intercom-Cordova] WARNING - displayConversationsList is deprecated. Please use displayMessenger instead.");
+    [Intercom presentMessenger];
     [self sendSuccess:command];
 }
 


### PR DESCRIPTION
**Enable mobile users to help themselves with the new mobile SDK for iOS and Android 🎉 😃**

The new Intercom mobile SDK brings the Messenger Home to your mobile applications. This means you can add messenger apps that allow your users to self-serve instead of starting a conversation. Users can now quickly access relevant help articles, review pinned content, and view product status in real time – all from the messenger home screen.

![android-release-screens](https://user-images.githubusercontent.com/2615468/42951497-316de29a-8b6e-11e8-8ed8-a0a3a93f6f4f.png)

![ios-release-screens](https://user-images.githubusercontent.com/3185423/42937925-71ab4b5c-8b48-11e8-913b-88d48c9b82f3.png)

**API changes**

* `displayConversationsList` - Use `displayMessenger` instead.

These deprecated methods will still work, but will be removed in a future release. 