### PR TITLE
Fix CI for the publish job

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -67,8 +67,8 @@ jobs:
       - run:
           name: Install node/npm
           command: |
-            curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-            sudo apt-get install -y nodejs
+            curl -sL https://deb.nodesource.com/setup_10.x | sudo -E bash -
+            sudo apt install -y nodejs
       - run:
           name: Publish to npm
           command: |


### PR DESCRIPTION
Similar with the changes made in a previous PR https://github.com/intercom/intercom-cordova/pull/277/files 

The command resource needs an update for nodejs in order to install npm during the publish job.