### PR TITLE
Version 9.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Intercom for Cordova/PhoneGap
 
+## 9.1.0 (2020-07-20)
+
+* The Cordova plugin has been updated to be compatible with v7.2.0 of the Android SDK and v9.0.0 of Cordova Android.
+* v7.2.0 of the Android SDK now uses [Android X](https://developer.android.com/jetpack/androidx), and includes updates to the Gson and Firebase Messaging libraries it uses.
+* In [Cordova Android v9.0.0](https://cordova.apache.org/announcements/2020/06/29/cordova-android-9.0.0.html), the minimum Android API level is now API 22 (Android 5.1). The Cordova plugin's minimum version is now API 22 as well.
+
 ## 9.0.1 (2020-07-08)
 
 The Intercom Cordova plugin has been updated to use v7.1.1 of the iOS and Android SDK. We fixed a number of bugs in this release:

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~9.0.1" />
+<plugin name="cordova-plugin-intercom" version="~9.1.0" />
 ```
 
 ## Example App

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "9.0.1",
+  "version": "9.1.0",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="9.0.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="9.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>


### PR DESCRIPTION
* The Cordova plugin has been updated to be compatible with v7.2.0 of the Android SDK and v9.0.0 of Cordova Android.
* v7.2.0 of the Android SDK now uses [Android X](https://developer.android.com/jetpack/androidx), and includes updates to the Gson and Firebase Messaging libraries it uses.
* In [Cordova Android v9.0.0](https://cordova.apache.org/announcements/2020/06/29/cordova-android-9.0.0.html), the minimum Android API level is now API 22 (Android 5.1). The Cordova plugin's minimum version is now API 22 as well.