### PR TITLE
Updated names of used configuration variables

### DIFF
--- a/intercom-plugin/src/android/build-extras-intercom.gradle
+++ b/intercom-plugin/src/android/build-extras-intercom.gradle
@@ -51,18 +51,18 @@ private static String guideUrl() {
 private void logIfIncorrectCompileSdkVersion() {
     // this can be `{number}` or `android-{number}`
     // regex checks that it ends with a number between 16 and 26 inclusive
-    if (cdvCompileSdkVersion != null && cdvCompileSdkVersion =~ /.*(1[6-9]|2[0-6])$/) {
-        logger.error("${errorPrefix()} cdvCompileSdkVersion = ${cdvCompileSdkVersion}. \n" +
-                "You need to use a cdvCompileSdkVersion of at least 27.\n" +
+    if (cordovaConfig.SDK_VERSION != null && cordovaConfig.SDK_VERSION =~ /.*(1[6-9]|2[0-6])$/) {
+        logger.error("${errorPrefix()} cordovaConfig.SDK_VERSION = ${cordovaConfig.SDK_VERSION}. \n" +
+                "You need to use a cordovaConfig.SDK_VERSION of at least 27.\n" +
                 "See here for more: ${guideUrl()}\n")
     }
 }
 
 private void logIfIncorrectBuildToolsVersion() {
     // regex checks for a major version between 16 and 26 inclusive
-    if (cdvBuildToolsVersion != null && cdvBuildToolsVersion =~ /(1[6-9]|2[0-6])\..+$/) {
-        logger.error("${errorPrefix()}  cdvBuildToolsVersion = ${cdvBuildToolsVersion}. \n" +
-                "You need to use a cdvBuildToolsVersion of at least 27.0.0.\n" +
+    if (cordovaConfig.BUILD_TOOLS_VERSION != null && cordovaConfig.BUILD_TOOLS_VERSION =~ /(1[6-9]|2[0-6])\..+$/) {
+        logger.error("${errorPrefix()}  cordovaConfig.BUILD_TOOLS_VERSION = ${cordovaConfig.BUILD_TOOLS_VERSION}. \n" +
+                "You need to use a cordovaConfig.BUILD_TOOLS_VERSION of at least 27.0.0.\n" +
                 "See here for more: ${guideUrl()}\n")
     }
 }


### PR DESCRIPTION
cdvCompileSdkVersion and cdvBuildToolsVersion do not exist in cordova android 10 and have been replaced by cordovaConfig.SDK_VERSION and cordovaConfig.BUILD_TOOLS_VERSION. Without this change, plugin fails to sync project with gradle files.