### PR TITLE
Explicitly set Android version as 10.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Intercom for Cordova/PhoneGap
 
+## 10.1.1 (2021-09-14)
+* Include dependencies needed to make the Android version build
+
 ## 10.1.0 (2021-08-23)
 * The Intercom Cordova plugin has been updated to use the latest version (v10.1.0) of the Intercom iOS and Android SDK
 * Updated to cordova-android 10.0.0

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="~10.1.0" />
+<plugin name="cordova-plugin-intercom" version="~10.1.1" />
 ```
 
 ## Example App

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "10.1.0",
+  "version": "10.1.1",
   "description": "Official Cordova/PhoneGap plugin for Intercom",
   "cordova": {
     "id": "cordova-plugin-intercom",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="10.1.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="10.1.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>
@@ -62,7 +62,7 @@
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods use-frameworks="true">
-              <pod name="Intercom" spec="~> 10.1.0" />
+              <pod name="Intercom" spec="~> 10.1.1" />
           </pods>
       </podspec>
     </platform>

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -70,7 +70,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "10.1.0");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "10.1.1");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case FCM: {

--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -29,6 +29,10 @@ repositories {
 
 dependencies {
     implementation 'io.intercom.android:intercom-sdk-base:10.+'
+    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation 'com.intercom:twig:1.3.0'
+    implementation 'org.jetbrains:annotations:13.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     if (pushType == 'fcm' || pushType == 'fcm-without-build-plugin') {
         implementation 'com.google.firebase:firebase-messaging:20.+'
         implementation 'io.intercom.android:intercom-sdk-fcm:10.+'

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -12,7 +12,7 @@
 @implementation IntercomBridge : CDVPlugin
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"10.1.0"];
+    [Intercom setCordovaVersion:@"10.1.1"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
In https://github.com/intercom/intercom-cordova/pull/306 we allowed a fuzzy match for the Android SDK. This stopped resolving dependencies of the SDK transitively. Setting explicit versions of the dependencies here fixes building the Example app