### PR TITLE
Release 14.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Intercom for Cordova/PhoneGap
 
+## 14.0.2 (2024-06-25)
+
+🐛 Bug Fixes
+* Now sets the minimum deployment target in the `plugin.xml` for iOS to avoid collisions with other plugins.
+
 ## 14.0.1 (2024-06-014)
 
 🚀 Enhancements

--- a/intercom-plugin/package-lock.json
+++ b/intercom-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-intercom",
-      "version": "14.0.1",
+      "version": "14.0.2",
       "license": "MIT License",
       "dependencies": {
         "q": "^1.5.1"

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "14.0.1",
+  "version": "14.0.2",
   "description": "Official Cordova plugin for Intercom",
   "author": "Intercom",
   "license": "MIT License",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -47,6 +47,7 @@
       <source-file src="src/ios/AppDelegate+IntercomPush.m" />
 
       <config-file target="config.xml" parent="/*">
+        <preference name="deployment-target" value="15.0"/>
         <feature name="Intercom">
           <param name="ios-package" value="IntercomBridge" />
           <param name="onload" value="true" />


### PR DESCRIPTION
## 14.0.2 (2024-06-25)

🐛 Bug Fixes
* Now sets the minimum deployment target in the `plugin.xml` for iOS to avoid collisions with other plugins.