### PR TITLE
Allow cordova-ios 7.1.1

### DIFF
--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -31,7 +31,7 @@
       "14.0.0": {
         "cordova": "=>12.0.0",
         "cordova-android": ">=13.0.0",
-        "cordova-ios": "7.1.0"
+        "cordova-ios": ">=7.1.0"
       }
     }
   }

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -10,7 +10,7 @@
     <engines>
       <engine name="cordova" version=">=12.0.0" />
       <engine name="cordova-android" version=">=13.0.0" />
-      <engine name="cordova-ios" version="7.1.0" />
+      <engine name="cordova-ios" version=">=7.1.0" />
     </engines>
 
     <js-module name="Intercom" src="www/intercom.js">


### PR DESCRIPTION
Upgrade cordova-ios to prevent this error message:

```
Plugin doesn't support this project's cordova-ios version. cordova-ios: 7.1.1, failed version requirement: 7.1.0
Skipping 'cordova-plugin-intercom' for ios
```