### PR TITLE
Release 16.0.0 — Update Intercom Android SDK to 18.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 ⚡ Important Changes
 * Minimum cordova-android version is now 15.0.0
 * Minimum Android compileSdk is now 36
-* Removed deprecated `handlePushMessage` API (no longer needed — the SDK now opens the chat screen directly when a push notification is tapped)
 * Internal storage migrated from SharedPreferences to AndroidX DataStore. Existing data is automatically migrated on first launch. This migration is one-way — downgrading to a previous SDK version will result in loss of local SDK state.
 
 ## 15.0.2 (2026-04-09)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Updated Intercom Android SDK to 18.0.0
 
 ⚡ Important Changes
+* Minimum cordova-android version is now 15.0.0
 * Minimum Android compileSdk is now 36
 * Removed deprecated `handlePushMessage` API (no longer needed — the SDK now opens the chat screen directly when a push notification is tapped)
 * Internal storage migrated from SharedPreferences to AndroidX DataStore. Existing data is automatically migrated on first launch. This migration is one-way — downgrading to a previous SDK version will result in loss of local SDK state.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Intercom for Cordova/PhoneGap
 
+## 16.0.0 (2026-04-09)
+
+🚀 Enhancements
+* Updated Intercom Android SDK to 18.0.0
+
+⚡ Important Changes
+* Minimum Android compileSdk is now 36
+* Removed deprecated `handlePushMessage` API (no longer needed — the SDK now opens the chat screen directly when a push notification is tapped)
+* Internal storage migrated from SharedPreferences to AndroidX DataStore. Existing data is automatically migrated on first launch. This migration is one-way — downgrading to a previous SDK version will result in loss of local SDK state.
+
 ## 15.0.2 (2026-04-09)
 
 🐛 Bug Fixes

--- a/Example/config.xml
+++ b/Example/config.xml
@@ -19,8 +19,8 @@
     <platform name="android">
         <allow-intent href="market:*" />
         <preference name="android-minSdkVersion" value="24" />
-        <preference name="android-targetSdkVersion" value="35" />
-        <preference name="android-compileSdkVersion" value="35" />
+        <preference name="android-targetSdkVersion" value="36" />
+        <preference name="android-compileSdkVersion" value="36" />
         <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application/activity[@android:name='MainActivity']">
             <activity android:exported="true" />
         </edit-config>

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -15,7 +15,7 @@
         },
         "../intercom-plugin": {
             "name": "cordova-plugin-intercom",
-            "version": "15.0.2",
+            "version": "16.0.0",
             "dev": true,
             "license": "MIT License",
             "dependencies": {

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -8,7 +8,7 @@
             "name": "io.intercom.cordova.sample",
             "version": "0.0.1",
             "devDependencies": {
-                "cordova-android": "^14.0.1",
+                "cordova-android": "^15.0.0",
                 "cordova-ios": "^7.1.1",
                 "cordova-plugin-intercom": "file:../intercom-plugin"
             }
@@ -31,6 +31,11 @@
                     "15.0.0": {
                         "cordova": ">=12.0.0",
                         "cordova-android": ">=14.0.0",
+                        "cordova-ios": ">=7.1.1"
+                    },
+                    "16.0.0": {
+                        "cordova": ">=12.0.0",
+                        "cordova-android": ">=15.0.0",
                         "cordova-ios": ">=7.1.1"
                     }
                 }
@@ -104,9 +109,9 @@
             "license": "ISC"
         },
         "node_modules/android-versions": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-2.1.0.tgz",
-            "integrity": "sha512-oCBvVs2uaL8ohQtesGs78/X7QvFDLbKgTosBRiOIBCss1a/yiakQm/ADuoG2k/AUaI0FfrsFeMl/a+GtEtjEeA==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/android-versions/-/android-versions-2.1.1.tgz",
+            "integrity": "sha512-dYeO3KHDO81WvEwZFK+OF0dJl/ESvxV3QZE/qo/AAnG/uijco6DOXJJla3CdoC8Eg53YBlbRIyobRGYqIAGw8Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -223,43 +228,62 @@
             "license": "MIT"
         },
         "node_modules/cordova-android": {
-            "version": "14.0.1",
-            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-14.0.1.tgz",
-            "integrity": "sha512-HMBMdGu/JlSQtmBuDEpKWf/pE75SpF3FksxZ+mqYuL3qSIN8lN/QsNurwYaPAP7zWXN2DNpvwlpOJItS5VhdLg==",
+            "version": "15.0.0",
+            "resolved": "https://registry.npmjs.org/cordova-android/-/cordova-android-15.0.0.tgz",
+            "integrity": "sha512-EpFSKUtBLJ7bTpuVD7NeC6toAooi5PI6VIR2jd8Ut5PJu7HSR5tPRwS87Q1DS03RSyDTlroB64JPUWC0pmAhnw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "android-versions": "^2.1.0",
-                "cordova-common": "^5.0.1",
-                "dedent": "^1.5.3",
+                "android-versions": "^2.1.1",
+                "cordova-common": "^6.0.0",
+                "dedent": "^1.7.1",
                 "execa": "^5.1.1",
                 "fast-glob": "^3.3.3",
                 "is-path-inside": "^3.0.3",
-                "nopt": "^8.1.0",
+                "nopt": "^9.0.0",
                 "properties-parser": "^0.6.0",
-                "semver": "^7.7.1",
-                "string-argv": "^0.3.1",
+                "semver": "^7.7.4",
+                "string-argv": "^0.3.2",
                 "untildify": "^4.0.0",
-                "which": "^5.0.0"
+                "which": "^6.0.1"
             },
             "engines": {
-                "node": ">=20.5.0"
+                "node": ">=20.17.0 || >=22.9.0"
             }
         },
         "node_modules/cordova-android/node_modules/abbrev": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
-            "integrity": "sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
+            "integrity": "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==",
             "dev": true,
             "license": "ISC",
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
+            }
+        },
+        "node_modules/cordova-android/node_modules/cordova-common": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/cordova-common/-/cordova-common-6.0.0.tgz",
+            "integrity": "sha512-16WPC1DuxVdshV3RoQUXqhcJVdhxWGwiFysA4TkYuboqoev6mgt0JuIJFxmQbzR/DuyuONaVe0L0O0Hf1C08Mg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@netflix/nerror": "^1.1.3",
+                "ansi": "^0.3.1",
+                "bplist-parser": "^0.3.2",
+                "elementtree": "^0.1.7",
+                "endent": "^2.1.0",
+                "fast-glob": "^3.3.3",
+                "plist": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=20.9.0"
             }
         },
         "node_modules/cordova-android/node_modules/dedent": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
-            "integrity": "sha512-9JmrhGZpOlEgOLdQgSm0zxFaYoQon408V1v49aqTWuXENVlnCuY9JBZcXZiCsZQWDjTm5Qf/nIvAy77mXDAjEg==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+            "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -271,36 +295,46 @@
                 }
             }
         },
+        "node_modules/cordova-android/node_modules/isexe": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-4.0.0.tgz",
+            "integrity": "sha512-FFUtZMpoZ8RqHS3XeXEmHWLA4thH+ZxCv2lOiPIn1Xc7CxrqhWzNSDzD+/chS/zbYezmiwWLdQC09JdQKmthOw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/cordova-android/node_modules/nopt": {
-            "version": "8.1.0",
-            "resolved": "https://registry.npmjs.org/nopt/-/nopt-8.1.0.tgz",
-            "integrity": "sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-9.0.0.tgz",
+            "integrity": "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "abbrev": "^3.0.0"
+                "abbrev": "^4.0.0"
             },
             "bin": {
                 "nopt": "bin/nopt.js"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/cordova-android/node_modules/which": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.1.tgz",
+            "integrity": "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "isexe": "^3.1.1"
+                "isexe": "^4.0.0"
             },
             "bin": {
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/cordova-common": {

--- a/Example/package.json
+++ b/Example/package.json
@@ -12,7 +12,7 @@
         }
     },
     "devDependencies": {
-        "cordova-android": "^14.0.1",
+        "cordova-android": "^15.0.0",
         "cordova-ios": "^7.1.1",
         "cordova-plugin-intercom": "file:../intercom-plugin"
     }

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 | Name      | Required Version |
 | ----------- | ----------- |
 |   cordova   |     12.0.0  |
-|   cordova-android   |     14.0.0  |
+|   cordova-android   |     15.0.0  |
 |   cordova-ios   |     7.1.1 |
 |   iOS SDK  |     15.0.0 |
 |   Android SDK   |     36 |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="15.0.2" />
+<plugin name="cordova-plugin-intercom" version="16.0.0" />
 ```
 
 ### Requirements
@@ -55,7 +55,7 @@ To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 |   cordova-android   |     14.0.0  |
 |   cordova-ios   |     7.1.1 |
 |   iOS SDK  |     15.0.0 |
-|   Android SDK   |     35 |
+|   Android SDK   |     36 |
 
 ## Example App
 

--- a/circle.yml
+++ b/circle.yml
@@ -49,7 +49,7 @@ jobs:
           command: npm install -g cordova
       - run:
           name: Add Android platform
-          command: cd Example && cordova platform add android@14.0.1
+          command: cd Example && cordova platform add android@15.0.0
       - run:
           name: Install intercom plugin
           command: cd Example && cordova plugin add ../intercom-plugin

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "15.0.2",
+  "version": "16.0.0",
   "description": "Official Cordova plugin for Intercom",
   "author": "Intercom",
   "license": "MIT License",
@@ -34,6 +34,11 @@
         "cordova-ios": ">=7.1.0"
       },
       "15.0.0": {
+        "cordova": ">=12.0.0",
+        "cordova-android": ">=14.0.0",
+        "cordova-ios": ">=7.1.1"
+      },
+      "16.0.0": {
         "cordova": ">=12.0.0",
         "cordova-android": ">=14.0.0",
         "cordova-ios": ">=7.1.1"

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -40,7 +40,7 @@
       },
       "16.0.0": {
         "cordova": ">=12.0.0",
-        "cordova-android": ">=14.0.0",
+        "cordova-android": ">=15.0.0",
         "cordova-ios": ">=7.1.1"
       }
     }

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -9,7 +9,7 @@
 
     <engines>
       <engine name="cordova" version=">=12.0.0" />
-      <engine name="cordova-android" version=">=14.0.0" />
+      <engine name="cordova-android" version=">=15.0.0" />
       <engine name="cordova-ios" version=">=7.1.1" />
     </engines>
 

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="15.0.2" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="16.0.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -65,8 +65,6 @@ public class IntercomBridge extends CordovaPlugin {
             @Override public void run() {
                 //We also initialize intercom here just in case it has died. If Intercom is already set up, this won't do anything.
                 setUpIntercom();
-
-                Intercom.client().handlePushMessage();
             }
         });
     }
@@ -79,7 +77,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "15.0.2");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "16.0.0");
 
             switch (IntercomPushManager.getInstalledModuleType()) {
                 case FCM: {

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -79,18 +79,6 @@ public class IntercomBridge extends CordovaPlugin {
 
             CordovaHeaderInterceptor.setCordovaVersion(context, "16.0.0");
 
-            switch (IntercomPushManager.getInstalledModuleType()) {
-                case FCM: {
-                    String senderId = getSenderId(context);
-
-                    if (senderId != null) {
-                        Log.d("Intercom-Cordova", "Using FCM Sender ID: " + senderId);
-                        IntercomPushManager.cacheSenderId(context, senderId);
-                    }
-                    break;
-                }
-            }
-
             //Get app credentials from config.xml or the app bundle if they can't be found
             String apiKey = preferences.getString("intercom-android-api-key", "");
             String appId = preferences.getString("intercom-app-id", "");
@@ -99,30 +87,6 @@ public class IntercomBridge extends CordovaPlugin {
         } catch (Exception e) {
             Log.e("Intercom-Cordova", "ERROR: Something went wrong when initializing Intercom. Have you set your APP_ID and ANDROID_API_KEY?", e);
         }
-    }
-
-    private String getSenderId(Context context) {
-        String preferencesSenderId = preferences.getString("intercom-android-sender-id", "");
-        String resourcesSenderId;
-        try {
-            // copied from `google-services.json` in our Gradle script
-            resourcesSenderId = context.getResources().getString(R.string.intercom_gcm_sender_id);
-        }
-        catch (Exception e) {
-            Log.d("Intercom-Cordova", "Failed to get sender ID from resources: ", e);
-            resourcesSenderId = "";
-        }
-
-        if (preferencesSenderId.isEmpty()) {
-            return resourcesSenderId;
-        }
-
-        // sometimes the XML parser Cordova uses formats numbers with scientific notation, giving an incorrect sender ID
-        // if this is the case, fall back to the ID from the `google-services.json` file
-        if (preferencesSenderId.contains(".") && !resourcesSenderId.isEmpty()) {
-            return resourcesSenderId;
-        }
-        return preferencesSenderId;
     }
 
     private enum Action {

--- a/intercom-plugin/src/android/IntercomInitProvider.java
+++ b/intercom-plugin/src/android/IntercomInitProvider.java
@@ -77,7 +77,7 @@ public class IntercomInitProvider extends ContentProvider {
                 return;
             }
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "15.0.2");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "16.0.0");
 
             Intercom.initialize((Application) context.getApplicationContext(), apiKey, appId);
             Log.d(TAG, "IntercomInitProvider: Intercom initialized successfully");

--- a/intercom-plugin/src/android/build-extras-intercom.gradle
+++ b/intercom-plugin/src/android/build-extras-intercom.gradle
@@ -10,9 +10,9 @@ afterEvaluate {
 }
 
 private void logIfIncorrectCompileSdkVersion() {
-    if (cordovaConfig.SDK_VERSION != null && cordovaConfig.SDK_VERSION < 34) {
+    if (cordovaConfig.SDK_VERSION != null && cordovaConfig.SDK_VERSION < 36) {
         throw new GradleException("Intercom Android Error: Your cordovaConfig.SDK_VERSION is [${cordovaConfig.SDK_VERSION}].\n"+
-                 "You need to use a cordovaConfig.SDK_VERSION of 34 or higher.\n"+
+                 "You need to use a cordovaConfig.SDK_VERSION of 36 or higher.\n"+
                  "See here for more: https://cordova.apache.org/docs/en/latest/guide/platforms/android/index.html#setting-gradle-properties\n")
     }
 }

--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -32,14 +32,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:17.4.7'
+    implementation 'io.intercom.android:intercom-sdk-base:18.0.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.intercom:twig:1.3.0'
     implementation 'org.jetbrains:annotations:13.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     if (pushType == 'fcm' || pushType == 'fcm-without-build-plugin') {
         implementation 'com.google.firebase:firebase-messaging:20.+'
-        implementation 'io.intercom.android:intercom-sdk-fcm:17.4.7'
+        implementation 'io.intercom.android:intercom-sdk-fcm:18.0.0'
     }
 }
 

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -16,7 +16,7 @@
 #pragma mark - Intercom Initialisation
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"15.0.2"];
+    [Intercom setCordovaVersion:@"16.0.0"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
### Why?

Intercom Android SDK 18.0.0 is a major release with important changes including migration from SharedPreferences to AndroidX DataStore and removal of deprecated push APIs. Bumping the Cordova wrapper to 16.0.0 to adopt these changes and signal breaking compatibility to consumers.

### How?

Bump Android SDK dependency from 17.4.7 to 18.0.0, remove the deleted `handlePushMessage()` call, raise the compileSdk validation to 36, and bump all wrapper version references to 16.0.0.

<sub>Generated with Claude Code</sub>