### PR TITLE
Fix npm publish by removing unnecessary scope config

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -68,7 +68,6 @@ jobs:
           name: Publish to npm
           command: |
             echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > intercom-plugin/.npmrc
-            npm config set scope $ORG_NAME
             cd intercom-plugin && npm publish
 
 workflows:


### PR DESCRIPTION
### Why?

The CircleCI publish job fails on newer npm versions because `npm config set scope` causes npm to look for scope-specific registry auth. When it doesn't find one, npm falls back to interactive browser-based authentication, which fails in CI.

### How?

Removed the unnecessary `npm config set scope $ORG_NAME` line from the publish job. This line was a leftover from a 2021 CI migration and is not needed — the package is unscoped.

<details>
<summary>Implementation Plan</summary>

# Fix: npm publish 404 for `cordova-plugin-intercom@16.1.0`

## Context

Two issues caused the publish failure:
1. **Expired NPM_TOKEN** — the token in CircleCI expired between the 16.0.0 and 16.1.0 releases
2. **`npm config set scope $ORG_NAME`** — a leftover line in `circle.yml` that causes newer npm versions (10+) on the updated CircleCI executor to trigger interactive browser auth instead of using the `.npmrc` token

## Completed

- [x] New Granular Access Token generated on npmjs.com (365-day expiry, scoped to `cordova-plugin-intercom`)
- [x] `NPM_TOKEN` updated in CircleCI environment variables
- [x] Removed `npm config set scope $ORG_NAME` from `circle.yml` line 71

## Remaining steps

1. **Delete and re-create the `16.1.0` tag** at the new commit so CircleCI picks up both the token fix and the config fix
2. **Monitor** the CircleCI publish job to confirm success

## Critical file

- `circle.yml` — single line removed (the `npm config set scope $ORG_NAME` line)

</details>

<sub>Generated with Claude Code</sub>