### PR TITLE
Release 16.4.0 — Update Intercom Android SDK to 18.5.0 and iOS SDK to 19.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Intercom for Cordova/PhoneGap
 
+## 16.4.0 (2026-07-20)
+
+✨ New Features
+* Added `suppressProactiveContent` to let host apps suppress carousel and survey content independently of in-app messages
+
+🚀 Enhancements
+* Updated Intercom Android SDK to 18.5.0
+* Updated Intercom iOS SDK to 19.7.0
+
 ## 16.3.1 (2026-07-01)
 
 🚀 Enhancements

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -17,7 +17,7 @@
         },
         "../intercom-plugin": {
             "name": "cordova-plugin-intercom",
-            "version": "16.3.1",
+            "version": "16.4.0",
             "dev": true,
             "license": "MIT License",
             "dependencies": {

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="16.3.1" />
+<plugin name="cordova-plugin-intercom" version="16.4.0" />
 ```
 
 ### Requirements

--- a/intercom-plugin/package-lock.json
+++ b/intercom-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "16.3.1",
+  "version": "16.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-intercom",
-      "version": "16.3.1",
+      "version": "16.4.0",
       "license": "MIT License",
       "dependencies": {
         "q": "^1.5.1"

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "16.3.1",
+  "version": "16.4.0",
   "description": "Official Cordova plugin for Intercom",
   "author": "Intercom",
   "license": "MIT License",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="16.3.1" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="16.4.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>
@@ -68,7 +68,7 @@
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods use-frameworks="true">
-              <pod name="Intercom" spec="~> 19.6.4" />
+              <pod name="Intercom" spec="~> 19.7.0" />
           </pods>
       </podspec>
     </platform>

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Arrays;
 
 import io.intercom.android.sdk.Intercom.Visibility;
+import io.intercom.android.sdk.Intercom.ContentType;
 import io.intercom.android.sdk.api.CordovaHeaderInterceptor;
 import io.intercom.android.sdk.api.UserUpdateRequest;
 import io.intercom.android.sdk.helpcenter.api.CollectionContentRequestCallback;
@@ -77,7 +78,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "16.3.1");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "16.4.0");
 
             //Get app credentials from config.xml or the app bundle if they can't be found
             String apiKey = preferences.getString("intercom-android-api-key", "");
@@ -382,6 +383,24 @@ public class IntercomBridge extends CordovaPlugin {
                     visibility = Intercom.GONE;
                 }
                 Intercom.client().setInAppMessageVisibility(visibility);
+                callbackContext.success();
+            }
+        },
+        suppressProactiveContent {
+            @Override void performAction(JSONArray args, CallbackContext callbackContext, CordovaInterface cordova) {
+                JSONArray typesArray = args.optJSONArray(0);
+                List<ContentType> types = new ArrayList<>();
+                if (typesArray != null) {
+                    for (int i = 0; i < typesArray.length(); i++) {
+                        String type = typesArray.optString(i);
+                        if ("CAROUSEL".equals(type)) {
+                            types.add(ContentType.CAROUSEL);
+                        } else if ("SURVEY".equals(type)) {
+                            types.add(ContentType.SURVEY);
+                        }
+                    }
+                }
+                Intercom.client().suppressProactiveContent(types);
                 callbackContext.success();
             }
         },

--- a/intercom-plugin/src/android/IntercomInitProvider.java
+++ b/intercom-plugin/src/android/IntercomInitProvider.java
@@ -77,7 +77,7 @@ public class IntercomInitProvider extends ContentProvider {
                 return;
             }
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "16.3.1");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "16.4.0");
 
             Intercom.initialize((Application) context.getApplicationContext(), apiKey, appId);
             Log.d(TAG, "IntercomInitProvider: Intercom initialized successfully");

--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -32,14 +32,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:18.3.2'
+    implementation 'io.intercom.android:intercom-sdk-base:18.5.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.intercom:twig:1.3.0'
     implementation 'org.jetbrains:annotations:13.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     if (pushType == 'fcm' || pushType == 'fcm-without-build-plugin') {
         implementation 'com.google.firebase:firebase-messaging:20.+'
-        implementation 'io.intercom.android:intercom-sdk-fcm:18.3.2'
+        implementation 'io.intercom.android:intercom-sdk-fcm:18.5.0'
     }
 }
 

--- a/intercom-plugin/src/ios/IntercomBridge.h
+++ b/intercom-plugin/src/ios/IntercomBridge.h
@@ -39,6 +39,7 @@
 - (void)setLauncherVisibility:(CDVInvokedUrlCommand*)command;
 - (void)setBottomPadding:(CDVInvokedUrlCommand*)command;
 - (void)setInAppMessageVisibility:(CDVInvokedUrlCommand*)command;
+- (void)suppressProactiveContent:(CDVInvokedUrlCommand*)command;
 - (void)hideIntercom:(CDVInvokedUrlCommand*)command;
     
 #pragma mark - Unread Conversation Count

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -16,7 +16,7 @@
 #pragma mark - Intercom Initialisation
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"16.3.1"];
+    [Intercom setCordovaVersion:@"16.4.0"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif
@@ -253,6 +253,20 @@
         visible = YES;
     }
     [Intercom setInAppMessagesVisible:visible];
+    [self sendSuccess:command];
+}
+
+- (void)suppressProactiveContent:(CDVInvokedUrlCommand*)command {
+    NSArray<NSString *> *typeStrings = command.arguments[0];
+    NSMutableArray<NSNumber *> *types = [NSMutableArray array];
+    for (NSString *typeString in typeStrings) {
+        if ([typeString isEqualToString:@"CAROUSEL"]) {
+            [types addObject:@(IntercomProactiveContentTypeCarousel)];
+        } else if ([typeString isEqualToString:@"SURVEY"]) {
+            [types addObject:@(IntercomProactiveContentTypeSurvey)];
+        }
+    }
+    [Intercom suppressProactiveContent:types];
     [self sendSuccess:command];
 }
 

--- a/intercom-plugin/www/intercom.js
+++ b/intercom-plugin/www/intercom.js
@@ -187,6 +187,16 @@ var intercom = {
     },
 
     /**
+     * Suppress the given proactive content types, independently of setInAppMessageVisibility.
+     * @note All proactive content is visible by default; pass an empty array to unsuppress all.
+     *
+     * @param types An array of content type strings to suppress, e.g. ["CAROUSEL", "SURVEY"].
+     */
+    suppressProactiveContent: function(types, success, error) {
+        cordova.exec(success, error, 'Intercom', 'suppressProactiveContent', [types]);
+    },
+
+    /**
      * Hide all Intercom windows that are currently displayed.
      * This will hide the Messenger, Help Center, Articles, and in-product messages (eg. Mobile Carousels, chats, and posts).
      */


### PR DESCRIPTION
### Why?

Bring the Cordova plugin's bundled native SDKs up to date with the latest public Intercom Android and iOS releases (two versions were pending on each platform), and expose the new `suppressProactiveContent` API both SDKs introduced.

### How?

Bump the Android SDK to 18.5.0 and iOS SDK to 19.7.0 across the plugin manifest, gradle config, and pod spec, then add a matching `suppressProactiveContent` bridge method (JS + Android + iOS) that maps content-type strings to each platform's native enum, mirroring the existing `presentContent`/`setInAppMessageVisibility` pattern.

<sub>Generated with Claude Code</sub>