### PR TITLE
Release 16.6.0 — Update Intercom Android SDK to 18.9.3 and iOS SDK to 19.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Intercom for Cordova/PhoneGap
 
+## 16.6.0 (2026-09-11)
+
+🚀 Enhancements
+* Updated Intercom Android SDK to 18.9.3
+* Updated Intercom iOS SDK to 19.8.1
+
 ## 16.5.0 (2026-07-31)
 
 🚀 Enhancements

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -17,7 +17,7 @@
         },
         "../intercom-plugin": {
             "name": "cordova-plugin-intercom",
-            "version": "16.5.0",
+            "version": "16.6.0",
             "dev": true,
             "license": "MIT License",
             "dependencies": {

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ cordova plugin add cordova-plugin-intercom
 
 To add the plugin to your PhoneGap app, add the following to your `config.xml`:
 ```xml
-<plugin name="cordova-plugin-intercom" version="16.5.0" />
+<plugin name="cordova-plugin-intercom" version="16.6.0" />
 ```
 
 ### Requirements

--- a/intercom-plugin/package-lock.json
+++ b/intercom-plugin/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "16.5.0",
+  "version": "16.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cordova-plugin-intercom",
-      "version": "16.5.0",
+      "version": "16.6.0",
       "license": "MIT License",
       "dependencies": {
         "q": "^1.5.1"

--- a/intercom-plugin/package.json
+++ b/intercom-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-intercom",
-  "version": "16.5.0",
+  "version": "16.6.0",
   "description": "Official Cordova plugin for Intercom",
   "author": "Intercom",
   "license": "MIT License",

--- a/intercom-plugin/plugin.xml
+++ b/intercom-plugin/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-intercom" version="16.5.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-intercom" version="16.6.0" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>Intercom</name>
     <author>Intercom</author>
     <license>MIT License</license>
@@ -68,7 +68,7 @@
               <source url="https://cdn.cocoapods.org/"/>
           </config>
           <pods use-frameworks="true">
-              <pod name="Intercom" spec="~> 19.7.1" />
+              <pod name="Intercom" spec="~> 19.8.1" />
           </pods>
       </podspec>
     </platform>

--- a/intercom-plugin/src/android/IntercomBridge.java
+++ b/intercom-plugin/src/android/IntercomBridge.java
@@ -78,7 +78,7 @@ public class IntercomBridge extends CordovaPlugin {
         try {
             Context context = cordova.getActivity().getApplicationContext();
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "16.5.0");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "16.6.0");
 
             //Get app credentials from config.xml or the app bundle if they can't be found
             String apiKey = preferences.getString("intercom-android-api-key", "");

--- a/intercom-plugin/src/android/IntercomInitProvider.java
+++ b/intercom-plugin/src/android/IntercomInitProvider.java
@@ -77,7 +77,7 @@ public class IntercomInitProvider extends ContentProvider {
                 return;
             }
 
-            CordovaHeaderInterceptor.setCordovaVersion(context, "16.5.0");
+            CordovaHeaderInterceptor.setCordovaVersion(context, "16.6.0");
 
             Intercom.initialize((Application) context.getApplicationContext(), apiKey, appId);
             Log.d(TAG, "IntercomInitProvider: Intercom initialized successfully");

--- a/intercom-plugin/src/android/intercom.gradle
+++ b/intercom-plugin/src/android/intercom.gradle
@@ -32,14 +32,14 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.intercom.android:intercom-sdk-base:18.6.0'
+    implementation 'io.intercom.android:intercom-sdk-base:18.9.3'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.intercom:twig:1.3.0'
     implementation 'org.jetbrains:annotations:13.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.0'
     if (pushType == 'fcm' || pushType == 'fcm-without-build-plugin') {
         implementation 'com.google.firebase:firebase-messaging:20.+'
-        implementation 'io.intercom.android:intercom-sdk-fcm:18.6.0'
+        implementation 'io.intercom.android:intercom-sdk-fcm:18.9.3'
     }
 }
 

--- a/intercom-plugin/src/ios/IntercomBridge.m
+++ b/intercom-plugin/src/ios/IntercomBridge.m
@@ -16,7 +16,7 @@
 #pragma mark - Intercom Initialisation
 
 - (void)pluginInitialize {
-    [Intercom setCordovaVersion:@"16.5.0"];
+    [Intercom setCordovaVersion:@"16.6.0"];
     #ifdef DEBUG
         [Intercom enableLogging];
     #endif


### PR DESCRIPTION
### Why?

Five Android SDK releases and three iOS SDK releases have shipped since the wrapper was last cut at 16.5.0, so Cordova apps are stuck on older native SDKs. This release picks them up.

### How?

Bumps the native Android dependency and iOS pod to the latest published versions, and the plugin version consistently everywhere it is recorded. No new native APIs landed in the intervening releases, so the wrapper surface is unchanged.

<sub>Generated with Claude Code</sub>